### PR TITLE
Add SIGHUP signal handler for TLS certificate reload (F5.4.3)

### DIFF
--- a/src/archerdb/main.zig
+++ b/src/archerdb/main.zig
@@ -19,6 +19,7 @@ const cli = @import("cli.zig");
 const inspect = @import("inspect.zig");
 const metrics_server = @import("metrics_server.zig");
 const tls_config = vsr.tls_config;
+const signal_handler = vsr.signal_handler;
 
 const IO = vsr.io.IO;
 const Time = vsr.time.Time;
@@ -582,6 +583,11 @@ fn command_start(
     // Update TLS metrics
     archerdb_metrics.Registry.setTlsEnabled(tls.isEnabled());
 
+    // Install SIGHUP handler for certificate reload (F5.4.3)
+    if (tls.isEnabled()) {
+        signal_handler.install();
+    }
+
     // TODO Panic if the data file's size is larger that args.storage_size_limit.
     // (Here or in Replica.open()?).
 
@@ -836,6 +842,18 @@ fn command_start(
 
     while (true) {
         replica.tick();
+
+        // Check for SIGHUP-triggered certificate reload (F5.4.3)
+        if (tls.isEnabled() and signal_handler.shouldReloadCertificates()) {
+            log.info("SIGHUP received, reloading TLS certificates", .{});
+            if (tls.reload()) |_| {
+                log.info("TLS certificates reloaded successfully", .{});
+                archerdb_metrics.Registry.recordCertReload();
+            } else |err| {
+                log.err("certificate reload failed: {} - keeping old certificates", .{err});
+                archerdb_metrics.Registry.recordCertReloadFailure();
+            }
+        }
 
         // Update VSR metrics (F5.2.2 - Observability)
         const status_code: i64 = switch (replica.status) {

--- a/src/archerdb/signal_handler.zig
+++ b/src/archerdb/signal_handler.zig
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024-2025 ArcherDB Contributors
+//! Signal Handler for TLS Certificate Reload (F5.4.3)
+//!
+//! This module provides SIGHUP signal handling for certificate reload.
+//! When SIGHUP is received, it sets a flag that the main loop checks
+//! to trigger TLS certificate reload.
+//!
+//! Per security/spec.md:
+//! - SIGHUP triggers certificate reload from configured paths
+//! - Gracefully transitions to new certificates
+//! - Existing connections unaffected (use old certificates until close)
+//! - New connections use new certificates immediately
+//!
+//! Usage:
+//! ```zig
+//! const signal_handler = @import("signal_handler.zig");
+//!
+//! // At startup
+//! signal_handler.install();
+//!
+//! // In main loop
+//! if (signal_handler.shouldReloadCertificates()) {
+//!     tls_config.reload() catch |err| {
+//!         // Handle reload failure
+//!     };
+//! }
+//! ```
+
+const std = @import("std");
+const posix = std.posix;
+const log = std.log.scoped(.signal_handler);
+
+/// Atomic flag indicating SIGHUP was received and certificates should be reloaded.
+/// Set by signal handler, cleared by main loop after reload attempt.
+pub var reload_certificates_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+/// Signal action for SIGHUP.
+const sighup_action = posix.Sigaction{
+    .handler = .{ .handler = sighupHandler },
+    .mask = posix.empty_sigset,
+    .flags = 0,
+};
+
+/// SIGHUP signal handler.
+/// Sets the reload flag - actual reload happens in main loop.
+/// Signal handlers must be async-signal-safe, so we only set an atomic flag.
+fn sighupHandler(_: i32) callconv(.c) void {
+    reload_certificates_flag.store(true, .release);
+    // Note: We cannot log here as logging is not async-signal-safe.
+    // The main loop will log when it processes the reload.
+}
+
+/// Install the SIGHUP signal handler.
+/// Call once at startup before the main loop.
+pub fn install() void {
+    posix.sigaction(posix.SIG.HUP, &sighup_action, null);
+    log.info("SIGHUP handler installed for certificate reload", .{});
+}
+
+/// Check if certificate reload was requested (via SIGHUP).
+/// Returns true once per SIGHUP signal - the flag is atomically cleared.
+pub fn shouldReloadCertificates() bool {
+    // Atomically check and clear the flag
+    return reload_certificates_flag.swap(false, .acq_rel);
+}
+
+/// Reset the reload flag without processing.
+/// Useful for error recovery or testing.
+pub fn clearReloadFlag() void {
+    reload_certificates_flag.store(false, .release);
+}
+
+/// Check if reload is pending without clearing.
+/// Useful for status checks.
+pub fn isReloadPending() bool {
+    return reload_certificates_flag.load(.acquire);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "signal_handler: flag initially false" {
+    // Reset to known state
+    clearReloadFlag();
+    try std.testing.expect(!isReloadPending());
+    try std.testing.expect(!shouldReloadCertificates());
+}
+
+test "signal_handler: shouldReloadCertificates clears flag" {
+    // Manually set the flag (simulating SIGHUP)
+    reload_certificates_flag.store(true, .release);
+
+    try std.testing.expect(isReloadPending());
+    try std.testing.expect(shouldReloadCertificates());
+    // Flag should now be cleared
+    try std.testing.expect(!isReloadPending());
+    try std.testing.expect(!shouldReloadCertificates());
+}
+
+test "signal_handler: clearReloadFlag resets" {
+    reload_certificates_flag.store(true, .release);
+    try std.testing.expect(isReloadPending());
+
+    clearReloadFlag();
+    try std.testing.expect(!isReloadPending());
+}

--- a/src/unit_tests.zig
+++ b/src/unit_tests.zig
@@ -11,6 +11,7 @@ comptime {
     _ = @import("archerdb/metrics.zig");
     _ = @import("archerdb/metrics_server.zig");
     _ = @import("archerdb/restore.zig");
+    _ = @import("archerdb/signal_handler.zig");
     _ = @import("archerdb/tls_config.zig");
     _ = @import("cdc/amqp.zig");
     _ = @import("cdc/amqp/protocol.zig");

--- a/src/vsr.zig
+++ b/src/vsr.zig
@@ -36,6 +36,7 @@ pub const backup_state = @import("archerdb/backup_state.zig");
 pub const restore = @import("archerdb/restore.zig");
 pub const backup_coordinator = @import("archerdb/backup_coordinator.zig");
 pub const backup_restore_test = @import("archerdb/backup_restore_test.zig");
+pub const signal_handler = @import("archerdb/signal_handler.zig");
 pub const lsm = .{
     .tree = @import("lsm/tree.zig"),
     .groove = @import("lsm/groove.zig"),


### PR DESCRIPTION
## Summary
- Adds SIGHUP signal handler for certificate hot-reload
- Main loop checks for reload flag and calls tls.reload()
- Existing connections unaffected, new connections use new certs

## Implementation Details

### Signal Handler Module (`src/archerdb/signal_handler.zig`)
- Async-signal-safe SIGHUP handler using atomic flag
- `install()`: Sets up SIGHUP signal handler at startup
- `shouldReloadCertificates()`: Atomically checks and clears reload flag
- 3 unit tests for signal flag behavior

### Main Loop Integration (`src/archerdb/main.zig`)
- Signal handler installed when TLS is enabled
- Main loop checks for reload flag on each tick
- On SIGHUP: logs, calls tls.reload(), records metrics

## How It Works
1. Send SIGHUP to the process: `kill -HUP <pid>`
2. Signal handler sets atomic flag (async-signal-safe)
3. Main loop detects flag, calls tls_config.reload()
4. New connections use new certificates
5. Existing connections unaffected (per spec)

## Metrics Integration
- `archerdb_tls_cert_reloads_total`: Incremented on successful reload
- `archerdb_tls_cert_reload_failures_total`: Incremented on failed reload

## Test plan
- [x] Signal handler unit tests pass (3/3)
- [x] `zig build check` compiles successfully
- [x] `zig fmt --check` passes
- [ ] CI passes (note: pre-existing test failure on main)

**Note:** This PR is based on #528 (TLS configuration foundation).

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)